### PR TITLE
ヘッダーとサイドバーコンポーネントの実装

### DIFF
--- a/src/app/(header)/layout.tsx
+++ b/src/app/(header)/layout.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { Header } from "@/components/Header";
+import { Sidebar } from "@/components/Sidebar";
 import { UserProvider } from "@/context/UserContext";
+import { Box, Flex } from "@chakra-ui/react";
 
 export default function HeaderLayout({
   children,
@@ -10,7 +12,19 @@ export default function HeaderLayout({
   return (
     <UserProvider>
       <Header />
-      {children}
+      <Flex>
+        <Sidebar />
+        <Box
+          ml={{ base: 0, md: "220px" }}
+          mt="60px"
+          pt={6}
+          px={5}
+          pb={5}
+          width="100%"
+        >
+          {children}
+        </Box>
+      </Flex>
     </UserProvider>
   );
 }

--- a/src/app/(header)/layout.tsx
+++ b/src/app/(header)/layout.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { Header } from "@/components/Header";
+import { UserProvider } from "@/context/UserContext";
+
+export default function HeaderLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <UserProvider>
+      <Header />
+      {children}
+    </UserProvider>
+  );
+}

--- a/src/app/(header)/partner/supplier/page.tsx
+++ b/src/app/(header)/partner/supplier/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Box, Heading, Text } from "@chakra-ui/react";
+
+export default function SupplierPage() {
+  return (
+    <Box>
+      <Heading as="h1" mb={4}>
+        仕入先
+      </Heading>
+      <Text>
+        ここは仕入先ページです。サイドバーのアクティブ状態をテストしています。
+      </Text>
+      <Text mt={4}>実際のコンテンツは別のPBIで実装予定です。</Text>
+    </Box>
+  );
+}

--- a/src/app/(noHeader)/login/page.tsx
+++ b/src/app/(noHeader)/login/page.tsx
@@ -16,6 +16,7 @@ import { PasswordInput } from "@/components/ui/password-input";
 import { useForm } from "react-hook-form";
 import { jwtDecode } from "jwt-decode";
 import { useMutation } from "@tanstack/react-query";
+import { LoginFormData, LoginResponse } from "@/types";
 
 import axiosClient from "@/lib/axiosClient";
 
@@ -45,19 +46,19 @@ export default function Login() {
     }
   }, [router]);
 
-  type LoginFormData = {
-    email: string;
-    password: string;
-  };
-
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<LoginFormData>();
 
-  const fetchLogin = async (LoginFormData: LoginFormData) => {
-    const { data } = await axiosClient.post("/api/auth/login/", LoginFormData);
+  const fetchLogin = async (
+    formData: LoginFormData
+  ): Promise<LoginResponse> => {
+    const { data } = await axiosClient.post<LoginResponse>(
+      "/api/auth/login/",
+      formData
+    );
     return data;
   };
 
@@ -73,11 +74,7 @@ export default function Login() {
   });
 
   return (
-    <form
-      onSubmit={handleSubmit((LoginFormData) =>
-        loginMutation.mutate(LoginFormData)
-      )}
-    >
+    <form onSubmit={handleSubmit((formData) => loginMutation.mutate(formData))}>
       <Flex minH="100vh" align="center" justify="center" bg="gray.50">
         <Fieldset.Root
           size="lg"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import {
   CloseButton,
   Drawer,
   Flex,
+  Link,
   Portal,
   Spinner,
   Text,
@@ -12,10 +13,12 @@ import { Avatar } from "@/components/ui/avatar";
 import { useRouter } from "next/navigation";
 
 import { useUser } from "@/context/UserContext";
+import { useLogout } from "@/hooks/useLogout";
 
 export const Header = () => {
   const router = useRouter();
   const { user, loading } = useUser();
+  const { logout } = useLogout();
 
   if (loading) {
     return (
@@ -68,6 +71,9 @@ export const Header = () => {
               <Drawer.Body>
                 <Text mb={4}>アカウント情報</Text>
                 <Text mb={4}>メールアドレス: {user?.email}</Text>
+                <Link onClick={logout} cursor="pointer">
+                  ログアウト
+                </Link>
               </Drawer.Body>
               <Drawer.CloseTrigger asChild>
                 <CloseButton size="sm" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,8 +36,16 @@ export const Header = () => {
       align="center"
       justify="space-between"
       px="6"
-      boxShadow="sm"
+      boxShadow="none"
+      borderBottom="1px solid"
+      borderColor="gray.200"
+      bg="white"
       gap="4"
+      position="fixed"
+      top="0"
+      left="0"
+      right="0"
+      zIndex="2"
     >
       <Text
         fontSize="xl"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {
+  CloseButton,
+  Drawer,
+  Flex,
+  Portal,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import { Avatar } from "@/components/ui/avatar";
+import { useRouter } from "next/navigation";
+
+import { useUser } from "@/context/UserContext";
+
+export const Header = () => {
+  const router = useRouter();
+  const { user, loading } = useUser();
+
+  if (loading) {
+    return (
+      <Flex align="center" justify="center" height="60px">
+        <Spinner size="sm" />
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      as="header"
+      width="100%"
+      height="60px"
+      align="center"
+      justify="space-between"
+      px="6"
+      boxShadow="sm"
+      gap="4"
+    >
+      <Text
+        fontSize="xl"
+        fontWeight="bold"
+        marginEnd="auto"
+        cursor="pointer"
+        onClick={() => {
+          router.push("/snippets/");
+        }}
+      >
+        zaiko
+      </Text>
+
+      <Drawer.Root>
+        <Drawer.Trigger asChild>
+          <Avatar
+            variant="solid"
+            name={`${user?.first_name} ${user?.last_name}`}
+            cursor="pointer"
+          />
+        </Drawer.Trigger>
+        <Portal>
+          <Drawer.Backdrop />
+          <Drawer.Positioner>
+            <Drawer.Content>
+              <Drawer.Header>
+                <Drawer.Title>
+                  {user && `${user.first_name} ${user.last_name}`}
+                </Drawer.Title>
+              </Drawer.Header>
+              <Drawer.Body>
+                <Text mb={4}>アカウント情報</Text>
+                <Text mb={4}>メールアドレス: {user?.email}</Text>
+              </Drawer.Body>
+              <Drawer.CloseTrigger asChild>
+                <CloseButton size="sm" />
+              </Drawer.CloseTrigger>
+            </Drawer.Content>
+          </Drawer.Positioner>
+        </Portal>
+      </Drawer.Root>
+    </Flex>
+  );
+};

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+/**
+ * サイドバーコンポーネント
+ *
+ * アプリケーションのメインナビゲーションを提供するサイドバー。
+ * 通常のナビゲーションリンクとアコーディオン形式の展開可能なサブメニューを含む。
+ */
+
+import { Box, Flex, Icon, Link, Accordion, Text } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { usePathname } from "next/navigation";
+import { IconType } from "react-icons";
+import { HiOutlineShoppingCart, HiOutlineUsers } from "react-icons/hi";
+
+// ========== 型定義 ==========
+
+interface NavItemProps {
+  icon: IconType;
+  children: React.ReactNode;
+  href: string;
+  active?: boolean;
+}
+
+interface SubMenuItemProps {
+  href: string;
+  active: boolean;
+  children: React.ReactNode;
+}
+
+// ========== 子コンポーネント ==========
+
+/**
+ * ナビゲーションリンク
+ *
+ * サイドバー内の個々のナビゲーションリンクを表示するコンポーネント。
+ * アイコンとテキストを含み、アクティブ状態に応じて視覚的にハイライトされる。
+ */
+const NavItem = ({ icon, children, href, active }: NavItemProps) => {
+  return (
+    <Link
+      as={NextLink}
+      href={href}
+      style={{ textDecoration: "none" }}
+      css={{
+        "&:focus": {
+          outline: "none",
+          boxShadow: "none",
+        },
+      }}
+    >
+      <Flex
+        align="center"
+        p="3"
+        mx="4"
+        h="45px"
+        width="100%"
+        borderRadius="lg"
+        role="group"
+        cursor="pointer"
+        fontWeight={active ? "bold" : "normal"}
+        bg={active ? "blue.50" : "transparent"}
+        color={active ? "blue.600" : "inherit"}
+        _hover={{
+          bg: "blue.50",
+          color: "blue.600",
+        }}
+        fontSize="sm"
+      >
+        {icon && <Icon mr="4" fontSize="20" as={icon} />}
+        <Text fontSize="sm" fontWeight={active ? "bold" : "normal"}>
+          {children}
+        </Text>
+      </Flex>
+    </Link>
+  );
+};
+
+/**
+ * サブメニューアイテム
+ *
+ * アコーディオン内のサブメニュー項目を表示するコンポーネント。
+ * 親メニューの内側にインデントされ、アクティブ状態に応じてハイライトされる。
+ */
+const SubMenuItem = ({ href, active, children }: SubMenuItemProps) => {
+  return (
+    <Link
+      as={NextLink}
+      href={href}
+      py={2}
+      pl={2}
+      pr={4}
+      borderRadius="md"
+      display="block"
+      color={active ? "blue.600" : "gray.700"}
+      bg={active ? "blue.50" : "transparent"}
+      fontWeight={active ? "bold" : "normal"}
+      _hover={{ textDecoration: "none", bg: "blue.50", color: "blue.600" }}
+      css={{
+        "&:focus": {
+          outline: "none",
+          boxShadow: "none",
+        },
+      }}
+    >
+      <Flex align="center">
+        <Text fontSize="sm" fontWeight={active ? "bold" : "normal"}>
+          {children}
+        </Text>
+      </Flex>
+    </Link>
+  );
+};
+
+// ========== メインコンポーネント ==========
+
+/**
+ * サイドバーのメインコンポーネント
+ *
+ * 現在のパスに基づいてアクティブなリンクをハイライトし、
+ * 通常のリンクとアコーディオン形式のサブメニューを含む。
+ */
+export const Sidebar = () => {
+  const pathname = usePathname();
+
+  return (
+    <Box
+      as="nav"
+      pos="fixed"
+      top="61px"
+      left="0"
+      h="calc(100vh - 61px)"
+      w="220px"
+      bg="white"
+      borderRight="1px"
+      borderRightColor="gray.200"
+      overflowY="auto"
+      display={{ base: "none", md: "block" }}
+      pt={5}
+      zIndex="1"
+    >
+      <Flex direction="column" as="nav" fontSize="sm">
+        {/* 通常のナビゲーションリンク */}
+        <NavItem
+          icon={HiOutlineShoppingCart}
+          href="/order"
+          active={pathname.includes("/order")}
+        >
+          発注
+        </NavItem>
+
+        {/* アコーディオンメニュー: 取引先 */}
+        <Accordion.Root collapsible variant="plain" width="100%">
+          <Accordion.Item value="partner" borderBottom="none" borderTop="none">
+            <Accordion.ItemTrigger>
+              <Flex
+                align="center"
+                p="3"
+                mx="4"
+                h="45px"
+                width="100%"
+                borderRadius="lg"
+                cursor="pointer"
+                fontSize="sm"
+                fontWeight="normal"
+                _hover={{ bg: "blue.50", color: "blue.600" }}
+                _focus={{ outline: "none", boxShadow: "none" }}
+                _active={{ outline: "none", boxShadow: "none" }}
+              >
+                <Icon as={HiOutlineUsers} mr="4" fontSize="20" />
+                <Text fontSize="sm" fontWeight="normal">
+                  取引先
+                </Text>
+                <Accordion.ItemIndicator ml="auto" />
+              </Flex>
+            </Accordion.ItemTrigger>
+            <Accordion.ItemContent>
+              <Accordion.ItemBody pl={8} pr={4}>
+                <Flex direction="column" gap={2} pb={2}>
+                  {/* サブメニュー: 仕入先 */}
+                  <SubMenuItem
+                    href="/partner/supplier"
+                    active={pathname.includes("/partner/supplier")}
+                  >
+                    仕入先
+                  </SubMenuItem>
+                </Flex>
+              </Accordion.ItemBody>
+            </Accordion.ItemContent>
+          </Accordion.Item>
+        </Accordion.Root>
+      </Flex>
+    </Box>
+  );
+};
+
+export default Sidebar;

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,34 @@
+import {
+  Avatar as ChakraAvatar,
+  AvatarGroup as ChakraAvatarGroup,
+} from "@chakra-ui/react"
+import * as React from "react"
+
+type ImageProps = React.ImgHTMLAttributes<HTMLImageElement>
+
+export interface AvatarProps extends ChakraAvatar.RootProps {
+  name?: string
+  src?: string
+  srcSet?: string
+  loading?: ImageProps["loading"]
+  icon?: React.ReactElement
+  fallback?: React.ReactNode
+}
+
+export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
+  function Avatar(props, ref) {
+    const { name, src, srcSet, loading, icon, fallback, children, ...rest } =
+      props
+    return (
+      <ChakraAvatar.Root ref={ref} {...rest}>
+        <ChakraAvatar.Fallback name={name}>
+          {icon || fallback}
+        </ChakraAvatar.Fallback>
+        <ChakraAvatar.Image src={src} srcSet={srcSet} loading={loading} />
+        {children}
+      </ChakraAvatar.Root>
+    )
+  },
+)
+
+export const AvatarGroup = ChakraAvatarGroup

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import axiosClient from "@/lib/axiosClient";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import { User } from "@/types";
+
+// Contextで管理するデータ型
+type UserContextType = {
+  user: User | null;
+  loading: boolean;
+  setUser: (user: User | null) => void;
+};
+
+// Contextの初期化
+const UserContext = createContext<UserContextType>({
+  user: null,
+  loading: true,
+  setUser: () => {},
+});
+
+// UserProvider: ユーザー情報を取得して全体に提供する
+export const UserProvider = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = useQueryClient();
+
+  const fetchUser = async (): Promise<User | null> => {
+    try {
+      const res = await axiosClient.get<User | { message: string }>(
+        "/api/auth/info/"
+      );
+
+      // レスポンスデータをチェック
+      // message プロパティがある場合は未認証レスポンス
+      if (
+        "message" in res.data &&
+        res.data.message === "user not authenticated"
+      ) {
+        return null;
+      }
+
+      // User型のレスポンスの場合
+      return res.data as User;
+    } catch (err) {
+      const error = err as AxiosError;
+      // エラーハンドリングはそのまま残す（他のエラーケース用）
+      throw error;
+    }
+  };
+
+  const { data: user, isLoading } = useQuery<User | null, AxiosError>({
+    queryKey: ["authUser"],
+    queryFn: fetchUser,
+    retry: false,
+    initialData: null,
+  });
+
+  // queryClient.setQueryData()でuserを更新
+  const setUser = (newUser: User | null) => {
+    if (newUser === null) {
+      // ログアウト時にキャッシュを無効化
+      queryClient.setQueryData(["authUser"], null);
+    } else {
+      // ユーザー情報を更新
+      queryClient.setQueryData(["authUser"], newUser);
+    }
+  };
+
+  return (
+    <UserContext.Provider value={{ user, loading: isLoading, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+// useUser: Contextの値を取得するカスタムフック
+export const useUser = () => useContext(UserContext);

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,20 @@
+import { useRouter } from "next/navigation";
+
+import { useUser } from "@/context/UserContext";
+
+export const useLogout = () => {
+  const router = useRouter();
+  const { setUser } = useUser();
+
+  const logout = () => {
+    // ローカルストレージのアクセストークンを削除
+    localStorage.removeItem("access_token");
+
+    // グローバルで管理しているユーザー情報をリセット
+    setUser(null);
+
+    router.push("/login");
+  };
+
+  return { logout };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./user";

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,29 @@
+/**
+ * ユーザー情報の型定義
+ * APIから取得されるユーザーデータの形式
+ */
+export type User = {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+  is_active: boolean;
+  is_staff: boolean;
+  is_superuser: boolean;
+};
+
+/**
+ * ログインフォームの型定義
+ */
+export type LoginFormData = {
+  email: string;
+  password: string;
+};
+
+/**
+ * ログインAPIのレスポンス型定義
+ */
+export type LoginResponse = {
+  access: string;
+  refresh?: string;
+};


### PR DESCRIPTION
## 概要
このプルリクエストでは、アプリケーションのヘッダーとサイドバーコンポーネントを実装しました。ヘッダーはユーザー情報の表示と操作を提供し、サイドバーはアプリケーション内の主要セクションへのナビゲーションを提供します。この変更によりアプリケーションの基本的なUI構造とナビゲーション体験が向上します。

## 変更内容
- **`Header` コンポーネントの実装**
  - ロゴ、ユーザー情報表示、ドロワー形式のユーザーメニューの実装
  - ユーザーログアウト機能の統合

- **`Sidebar` コンポーネントの実装**
  - シンプルで直感的なナビゲーションリンクの設定
  - アコーディオン形式の展開可能なサブメニューの実装
  - 現在のページに応じたアクティブ状態のハイライト機能

## テスト済み内容
- 認証ユーザー情報の取得・表示
- 各ページでのナビゲーション機能が正しく動作することを確認
- アコーディオンメニューの開閉が正常に動作することを確認
- ドロワーメニューの表示と操作が適切に機能することを確認
- 実装されたルートへの正しいリンクとアクティブ状態のハイライトを確認

## 関連情報
- 関連Issue: [#12 - ヘッダーとサイドバーの実装](https://github.com/goayasushi/zaiko-be/issues/2)