### PR TITLE
認証エラーハンドリングの実装

### DIFF
--- a/src/app/(noHeader)/error-auth/page.tsx
+++ b/src/app/(noHeader)/error-auth/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Alert } from "@/components/ui/alert";
+import { Box, Link, Text } from "@chakra-ui/react";
+import { LuExternalLink } from "react-icons/lu";
+
+import { useLogout } from "@/hooks/useLogout";
+
+export default function ErrorAuthPage() {
+  const { logout } = useLogout();
+
+  return (
+    <Box p="6">
+      <Alert status="error" title="認証エラーが発生しました">
+        <Text py="2">
+          ログインしていないか、セッションが切れている可能性があります。
+          下のリンクからログインしてください。
+        </Text>
+        <Link onClick={logout} variant="underline" cursor="pointer">
+          ログインページへ <LuExternalLink />
+        </Link>
+      </Alert>
+    </Box>
+  );
+}

--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -29,11 +29,13 @@ axiosClient.interceptors.response.use(
     return response;
   },
   (error) => {
-    // TODO: ログイン時の認証エラー処理とjwt期限切れで処理を分ける
-    // if (error.response?.status === 401) {
-    //   window.location.href = "/error-auth";
-    // }
-    console.log(error);
+    // jwtトークンエラーの場合はエラー画面へリダイレクト
+    if (
+      error.response?.status === 401 &&
+      error.response?.data.code === "token_not_valid"
+    ) {
+      window.location.href = "/error-auth";
+    }
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## 概要
JWTトークンの有効期限切れなどの認証エラーが発生した際の適切なエラーハンドリングを実装しました。

## 変更内容

### axiosClientの修正
- 401エラー時のハンドリングを実装
- トークンエラー発生時に`/error-auth`ページへリダイレクト

### error-authページの修正
- エラーメッセージの表示を実装
- ログインリンクにログアウト処理を追加
  - トークンの削除
  - ユーザーコンテキストのクリア
  - ログインページへのリダイレクト

## 関連情報
- 関連Issue: https://github.com/goayasushi/zaiko-be/issues/22