### PR TITLE
仕入先一覧画面の実装

### DIFF
--- a/src/app/(header)/partner/supplier/page.tsx
+++ b/src/app/(header)/partner/supplier/page.tsx
@@ -3,23 +3,64 @@
 import {
   Box,
   Button,
-  Heading,
-  Text,
-  Stack,
   Flex,
-  Spacer,
+  Heading,
+  Icon,
+  Stack,
+  Text,
+  Card,
+  Table,
 } from "@chakra-ui/react";
+import { HiChevronLeft, HiChevronRight } from "react-icons/hi";
 import { LuPlus } from "react-icons/lu";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 
-export default function SupplierPage() {
+import { Supplier, SupplierResponse } from "@/types";
+import axiosClient from "@/lib/axiosClient";
+
+// 仕入先データを取得する関数
+const fetchSuppliers = async (url: string): Promise<SupplierResponse> => {
+  const { data } = await axiosClient.get<SupplierResponse>(url);
+  return data;
+};
+
+export default function SupplierListPage() {
   const router = useRouter();
+  // APIのURLを状態として管理
+  const [apiUrl, setApiUrl] = useState("/api/masters/suppliers/");
+
+  // React Queryを使用してデータを取得
+  const {
+    data: suppliers,
+    isLoading,
+    isError,
+  } = useQuery<SupplierResponse>({
+    queryKey: ["suppliers", apiUrl],
+    queryFn: () => fetchSuppliers(apiUrl),
+    placeholderData: (previousData) => previousData,
+  });
+
+  // ページネーションハンドラー
+  const handlePrevPage = () => {
+    if (suppliers?.previous) {
+      setApiUrl(suppliers.previous);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (suppliers?.next) {
+      setApiUrl(suppliers.next);
+    }
+  };
 
   return (
     <Box>
-      <Flex align="center" mb={6}>
-        <Heading as="h1">仕入先一覧</Heading>
-        <Spacer minW="50px" />
+      <Flex justify="space-between" align="center" mb={6}>
+        <Heading as="h1" size="lg">
+          仕入先
+        </Heading>
         <Stack direction="row" gap={2}>
           <Button
             variant="solid"
@@ -32,7 +73,79 @@ export default function SupplierPage() {
         </Stack>
       </Flex>
 
-      <Text>仕入先一覧のコンテンツはこの後に実装予定です。</Text>
+      {isLoading ? (
+        <Text>読み込み中...</Text>
+      ) : isError ? (
+        <Text color="red.500">エラーが発生しました。再度お試しください。</Text>
+      ) : suppliers ? (
+        <>
+          <Card.Root>
+            <Box overflowX="auto">
+              <Table.Root interactive variant="outline" showColumnBorder>
+                <Table.Header bg="gray.50">
+                  <Table.Row>
+                    <Table.Cell fontWeight="bold">仕入先名</Table.Cell>
+                    <Table.Cell fontWeight="bold">仕入先コード</Table.Cell>
+                    <Table.Cell fontWeight="bold">住所</Table.Cell>
+                    <Table.Cell fontWeight="bold">電話番号</Table.Cell>
+                    <Table.Cell fontWeight="bold">メールアドレス</Table.Cell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {suppliers.results.map((supplier: Supplier) => (
+                    <Table.Row
+                      key={supplier.id}
+                      onClick={() => router.push(`#`)}
+                    >
+                      <Table.Cell>{supplier.name}</Table.Cell>
+                      <Table.Cell>{supplier.supplier_code}</Table.Cell>
+                      <Table.Cell>{`${supplier.prefecture}${supplier.city}`}</Table.Cell>
+                      <Table.Cell>{supplier.phone}</Table.Cell>
+                      <Table.Cell>{supplier.email}</Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            </Box>
+          </Card.Root>
+
+          <Flex
+            mt={4}
+            justify="space-between"
+            align="center"
+            fontSize="sm"
+            color="gray.600"
+          >
+            <Flex align="center" gap={1}>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={!suppliers.previous}
+                onClick={handlePrevPage}
+              >
+                <Icon as={HiChevronLeft} />
+              </Button>
+              <Text>
+                {suppliers.current} / {suppliers.total_pages}
+              </Text>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={!suppliers.next}
+                onClick={handleNextPage}
+              >
+                <Icon as={HiChevronRight} />
+              </Button>
+            </Flex>
+
+            <Flex align="center" gap={2}>
+              <Text>
+                {suppliers.page_size}件/ページ 全{suppliers.count || 0}件
+              </Text>
+            </Flex>
+          </Flex>
+        </>
+      ) : null}
     </Box>
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,27 @@
+import { Supplier } from "./supplier";
+
+/**
+ * ページネーション付きAPIレスポンスの共通型
+ * T: 結果配列の要素の型
+ */
+export interface PaginationResponse<T> {
+  /** 総アイテム数 */
+  count: number;
+  /** 総ページ数 */
+  total_pages: number;
+  /** 現在のページ番号 */
+  current: number;
+  /** 1ページあたりのアイテム数 */
+  page_size: number;
+  /** 次のページのURL (最後のページではnull) */
+  next: string | null;
+  /** 前のページのURL (最初のページではnull) */
+  previous: string | null;
+  /** 結果の配列 */
+  results: T[];
+}
+
+/**
+ * 仕入先一覧APIレスポンスの型
+ */
+export type SupplierResponse = PaginationResponse<Supplier>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./user";
 export * from "./supplier";
+export * from "./api";


### PR DESCRIPTION
## 概要

このプルリクエストでは、サプライヤー（仕入先）一覧画面を実装しました。バックエンドAPIと連携して仕入先情報を一覧表示し、ページネーション機能を備えたインターフェースを提供しています。

## 変更内容

- 仕入先一覧画面の実装
  - テーブル形式での仕入先情報（仕入先名、仕入先コード、住所、電話番号、メールアドレス）の表示

- ページネーション機能の実装
  - Django REST Frameworkのページネーションと連携
  - 前後ページへの移動ボタン
  - 現在のページ位置とページ数の表示
  - 1ページあたりの表示件数と総件数の表示

## 関連情報
- 関連Issue: https://github.com/goayasushi/zaiko-be/issues/14