### PR TITLE
サプライヤー詳細・編集・削除機能の実装

### DIFF
--- a/src/app/(header)/partner/supplier/[id]/SupplierEditForm.tsx
+++ b/src/app/(header)/partner/supplier/[id]/SupplierEditForm.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import {
+  Box,
+  Button,
+  Flex,
+  Grid,
+  Heading,
+  Input,
+  Stack,
+  Textarea,
+  Field,
+  NativeSelect,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { LuSave } from "react-icons/lu";
+
+import { Supplier, SupplierFormData } from "@/types";
+import { PREFECTURES } from "@/constants/prefectures";
+
+interface SupplierEditFormProps {
+  supplier: Supplier;
+  onSubmit: (data: SupplierFormData) => void;
+  isSubmitting: boolean;
+}
+
+export default function SupplierEditForm({
+  supplier,
+  onSubmit,
+  isSubmitting,
+}: SupplierEditFormProps) {
+  // React Hook Formの設定
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<SupplierFormData>();
+
+  // フォームの初期値を設定
+  useEffect(() => {
+    if (supplier) {
+      // フォームの初期値を設定
+      Object.entries(supplier).forEach(([key, value]) => {
+        if (key !== "id" && key !== "created_at" && key !== "updated_at") {
+          setValue(key as keyof SupplierFormData, value as string);
+        }
+      });
+    }
+  }, [supplier, setValue]);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <Text mb={4} color="red.500" fontSize="sm">
+        *は必須項目です
+      </Text>
+      <Stack gap={8}>
+        {/* 基本情報セクション */}
+        <Box>
+          <Heading size="md" mb={4}>
+            基本情報
+          </Heading>
+          <Grid templateColumns="repeat(2, 1fr)" gap={6}>
+            {/* 仕入先名 */}
+            <Box>
+              <Field.Root required invalid={!!errors.name}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  仕入先名
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <Input
+                  placeholder="例: 株式会社サンプル"
+                  {...register("name", {
+                    required: "仕入先名は必須です",
+                    maxLength: {
+                      value: 200,
+                      message: "仕入先名は200文字以内で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.name?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* 仕入先コード */}
+            <Box>
+              <Field.Root invalid={!!errors.supplier_code}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  仕入先コード
+                </Field.Label>
+                <Input
+                  placeholder="例: SUP001"
+                  {...register("supplier_code", {
+                    maxLength: {
+                      value: 50,
+                      message: "仕入先コードは50文字以内で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>
+                  {errors.supplier_code?.message}
+                </Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* 担当者 */}
+            <Box>
+              <Field.Root invalid={!!errors.contact_person}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  担当者
+                </Field.Label>
+                <Input
+                  placeholder="例: 山田太郎"
+                  {...register("contact_person", {
+                    maxLength: {
+                      value: 100,
+                      message: "担当者名は100文字以内で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>
+                  {errors.contact_person?.message}
+                </Field.ErrorText>
+              </Field.Root>
+            </Box>
+            {/* 空の要素（スペース用） */}
+            <Box></Box>
+
+            {/* 電話番号 */}
+            <Box>
+              <Field.Root required invalid={!!errors.phone}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  電話番号
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <Input
+                  placeholder="例: 03-1234-5678"
+                  {...register("phone", {
+                    required: "電話番号は必須です",
+                    maxLength: {
+                      value: 50,
+                      message: "電話番号は50文字以内で入力してください",
+                    },
+                    pattern: {
+                      value: /^[0-9\-\(\)]+$/,
+                      message: "正しい電話番号の形式で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.phone?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* FAX */}
+            <Box>
+              <Field.Root invalid={!!errors.fax}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  FAX
+                </Field.Label>
+                <Input
+                  placeholder="例: 03-1234-5678"
+                  {...register("fax", {
+                    maxLength: {
+                      value: 50,
+                      message: "FAX番号は50文字以内で入力してください",
+                    },
+                    pattern: {
+                      value: /^[0-9\-\(\)]+$/,
+                      message: "正しいFAX番号の形式で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.fax?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* メールアドレス */}
+            <Box>
+              <Field.Root required invalid={!!errors.email}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  メールアドレス
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <Input
+                  placeholder="例: info@example.com"
+                  {...register("email", {
+                    required: "メールアドレスは必須です",
+                    pattern: {
+                      value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                      message: "正しいメールアドレスの形式で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.email?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* ウェブサイト */}
+            <Box>
+              <Field.Root invalid={!!errors.website}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  ウェブサイト
+                </Field.Label>
+                <Input
+                  placeholder="例: https://www.example.com"
+                  {...register("website", {
+                    pattern: {
+                      value:
+                        /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([\/\w .-]*)*\/?$/,
+                      message: "正しいURLの形式で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.website?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+          </Grid>
+        </Box>
+
+        {/* 住所情報セクション */}
+        <Box>
+          <Heading size="md" mb={4}>
+            住所情報
+          </Heading>
+          <Flex gap={10} flexWrap="wrap">
+            {/* 郵便番号 */}
+            <Box minW="200px">
+              <Field.Root required invalid={!!errors.postal_code}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  郵便番号
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <Input
+                  placeholder="例: 123-4567"
+                  {...register("postal_code", {
+                    required: "郵便番号は必須です",
+                    maxLength: {
+                      value: 10,
+                      message: "郵便番号は10文字以内で入力してください",
+                    },
+                    pattern: {
+                      value: /^\d{3}-?\d{4}$/,
+                      message:
+                        "正しい郵便番号の形式で入力してください（例: 123-4567）",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.postal_code?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* 都道府県 */}
+            <Box minW="200px">
+              <Field.Root required invalid={!!errors.prefecture}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  都道府県
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <NativeSelect.Root>
+                  <NativeSelect.Field
+                    placeholder="選択してください"
+                    {...register("prefecture", {
+                      required: "都道府県は必須です",
+                    })}
+                  >
+                    {PREFECTURES.map((pref) => (
+                      <option key={pref} value={pref}>
+                        {pref}
+                      </option>
+                    ))}
+                  </NativeSelect.Field>
+                  <NativeSelect.Indicator />
+                </NativeSelect.Root>
+                <Field.ErrorText>{errors.prefecture?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* 市区町村 */}
+            <Box minW="200px">
+              <Field.Root required invalid={!!errors.city}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  市区町村
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <Input
+                  placeholder="例: 渋谷区"
+                  {...register("city", {
+                    required: "市区町村は必須です",
+                    maxLength: {
+                      value: 100,
+                      message: "市区町村は100文字以内で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.city?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* 町名・番地 */}
+            <Box minW="200px">
+              <Field.Root required invalid={!!errors.town}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  町名・番地
+                  <Field.RequiredIndicator />
+                </Field.Label>
+                <Input
+                  placeholder="例: 渋谷1-2-3"
+                  {...register("town", {
+                    required: "町名・番地は必須です",
+                    maxLength: {
+                      value: 200,
+                      message: "町名・番地は200文字以内で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.town?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+
+            {/* 建物名 */}
+            <Box minW="200px">
+              <Field.Root invalid={!!errors.building}>
+                <Field.Label fontSize="sm" color="gray.500" mb={1}>
+                  建物名
+                </Field.Label>
+                <Input
+                  placeholder="例: 渋谷ビル101"
+                  {...register("building", {
+                    maxLength: {
+                      value: 200,
+                      message:
+                        "建物名・部屋番号は200文字以内で入力してください",
+                    },
+                  })}
+                />
+                <Field.ErrorText>{errors.building?.message}</Field.ErrorText>
+              </Field.Root>
+            </Box>
+          </Flex>
+        </Box>
+
+        {/* 備考セクション */}
+        <Box>
+          <Heading size="md" mb={4}>
+            備考
+          </Heading>
+          <Field.Root invalid={!!errors.remarks}>
+            <Field.Label fontSize="sm" color="gray.500" mb={1}>
+              備考
+            </Field.Label>
+            <Textarea
+              placeholder="備考があれば入力してください"
+              rows={5}
+              {...register("remarks", {
+                maxLength: {
+                  value: 2000,
+                  message: "備考は2000文字以内で入力してください",
+                },
+              })}
+            />
+            <Field.ErrorText>{errors.remarks?.message}</Field.ErrorText>
+          </Field.Root>
+        </Box>
+
+        {/* 保存ボタン */}
+        <Flex justify="flex-end">
+          <Button
+            colorScheme="blue"
+            type="submit"
+            disabled={isSubmitting}
+            ml="auto"
+          >
+            <LuSave style={{ marginRight: "8px" }} />
+            保存
+          </Button>
+        </Flex>
+      </Stack>
+    </form>
+  );
+}

--- a/src/app/(header)/partner/supplier/[id]/page.tsx
+++ b/src/app/(header)/partner/supplier/[id]/page.tsx
@@ -14,16 +14,30 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useParams, useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
-import { LuArrowLeft } from "react-icons/lu";
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { LuArrowLeft, LuPencil, LuX } from "react-icons/lu";
 
-import { Supplier } from "@/types";
+import { Supplier, SupplierFormData } from "@/types";
 import axiosClient from "@/lib/axiosClient";
+import SupplierEditForm from "./SupplierEditForm";
 
 // 仕入先詳細データを取得する関数
 const fetchSupplierDetail = async (id: string): Promise<Supplier> => {
   const { data } = await axiosClient.get<Supplier>(
     `/api/masters/suppliers/${id}/`
+  );
+  return data;
+};
+
+// 仕入先を更新する関数
+const updateSupplier = async (
+  id: string,
+  formData: SupplierFormData
+): Promise<Supplier> => {
+  const { data } = await axiosClient.put<Supplier>(
+    `/api/masters/suppliers/${id}/`,
+    formData
   );
   return data;
 };
@@ -47,7 +61,9 @@ const DetailItem = ({
 export default function SupplierDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const supplierId = params.id as string;
+  const [isEditing, setIsEditing] = useState(false);
 
   // 仕入先詳細データの取得
   const {
@@ -58,6 +74,32 @@ export default function SupplierDetailPage() {
     queryKey: ["supplier", supplierId],
     queryFn: () => fetchSupplierDetail(supplierId),
   });
+
+  // 更新ミューテーション
+  const updateMutation = useMutation({
+    mutationFn: (data: SupplierFormData) => updateSupplier(supplierId, data),
+    onSuccess: () => {
+      // キャッシュの無効化
+      queryClient.invalidateQueries({ queryKey: ["suppliers"] });
+      queryClient.invalidateQueries({ queryKey: ["supplier", supplierId] });
+
+      // 編集モードを終了
+      setIsEditing(false);
+    },
+    onError: (error) => {
+      console.error("更新エラー:", error);
+    },
+  });
+
+  // 編集モードの切り替え
+  const toggleEditMode = () => {
+    setIsEditing(!isEditing);
+  };
+
+  // フォーム送信ハンドラー
+  const handleSubmit = (data: SupplierFormData) => {
+    updateMutation.mutate(data);
+  };
 
   if (isLoading) {
     return <Text>読み込み中...</Text>;
@@ -101,60 +143,87 @@ export default function SupplierDetailPage() {
             </IconButton>
             <Heading size="lg">仕入先詳細</Heading>
           </Flex>
+          {!isEditing ? (
+            <Button onClick={toggleEditMode}>
+              <LuPencil style={{ marginRight: "8px" }} />
+              編集
+            </Button>
+          ) : (
+            <Flex gap={2}>
+              <Button
+                variant="outline"
+                onClick={toggleEditMode}
+                disabled={updateMutation.isPending}
+              >
+                <LuX style={{ marginRight: "8px" }} />
+                キャンセル
+              </Button>
+            </Flex>
+          )}
         </Flex>
 
-        {/* 詳細情報 */}
+        {/* 詳細情報 / 編集フォーム */}
         <Card.Root>
           <Card.Body p={6}>
-            <Stack gap={8}>
-              {/* 基本情報セクション */}
-              <Box>
-                <Heading size="md" mb={4}>
-                  基本情報
-                </Heading>
-                <Grid templateColumns="repeat(2, 1fr)" gap={6}>
-                  <DetailItem label="仕入先名" value={supplier.name} />
-                  <DetailItem
-                    label="仕入先コード"
-                    value={supplier.supplier_code}
-                  />
-                  <GridItem colSpan={2}>
-                    <DetailItem
-                      label="担当者"
-                      value={supplier.contact_person}
-                    />
-                  </GridItem>
-                  <DetailItem label="電話番号" value={supplier.phone} />
-                  <DetailItem label="FAX" value={supplier.fax} />
-                  <DetailItem label="メールアドレス" value={supplier.email} />
-                  <DetailItem label="ウェブサイト" value={supplier.website} />
-                </Grid>
-              </Box>
-
-              {/* 住所情報セクション */}
-              <Box>
-                <Heading size="md" mb={4}>
-                  住所情報
-                </Heading>
-                <Flex justify="flex-start" gap={10}>
-                  <DetailItem label="郵便番号" value={supplier.postal_code} />
-                  <DetailItem label="都道府県" value={supplier.prefecture} />
-                  <DetailItem label="市区町村" value={supplier.city} />
-                  <DetailItem label="町名・番地" value={supplier.town} />
-                  <DetailItem label="建物名" value={supplier.building} />
-                </Flex>
-              </Box>
-
-              {/* 備考セクション */}
-              {supplier.remarks && (
+            {isEditing ? (
+              // 編集モード - 別コンポーネントとして分離
+              <SupplierEditForm
+                supplier={supplier}
+                onSubmit={handleSubmit}
+                isSubmitting={updateMutation.isPending}
+              />
+            ) : (
+              // 表示モード
+              <Stack gap={8}>
+                {/* 基本情報セクション */}
                 <Box>
                   <Heading size="md" mb={4}>
-                    備考
+                    基本情報
                   </Heading>
-                  <Text whiteSpace="pre-wrap">{supplier.remarks}</Text>
+                  <Grid templateColumns="repeat(2, 1fr)" gap={6}>
+                    <DetailItem label="仕入先名" value={supplier.name} />
+                    <DetailItem
+                      label="仕入先コード"
+                      value={supplier.supplier_code}
+                    />
+                    <GridItem colSpan={2}>
+                      <DetailItem
+                        label="担当者"
+                        value={supplier.contact_person}
+                      />
+                    </GridItem>
+                    <DetailItem label="電話番号" value={supplier.phone} />
+                    <DetailItem label="FAX" value={supplier.fax} />
+                    <DetailItem label="メールアドレス" value={supplier.email} />
+                    <DetailItem label="ウェブサイト" value={supplier.website} />
+                  </Grid>
                 </Box>
-              )}
-            </Stack>
+
+                {/* 住所情報セクション */}
+                <Box>
+                  <Heading size="md" mb={4}>
+                    住所情報
+                  </Heading>
+                  <Flex justify="flex-start" gap={10} flexWrap="wrap">
+                    <DetailItem label="郵便番号" value={supplier.postal_code} />
+                    <DetailItem label="都道府県" value={supplier.prefecture} />
+                    <DetailItem label="市区町村" value={supplier.city} />
+                    <DetailItem label="町名・番地" value={supplier.town} />
+                    <DetailItem label="建物名" value={supplier.building} />
+                  </Flex>
+                </Box>
+
+                {/* 備考セクション */}
+                {supplier.remarks && (
+                  <Box>
+                    <Heading size="md" mb={4}>
+                      備考
+                    </Heading>
+                    <Text whiteSpace="pre-wrap">{supplier.remarks}</Text>
+                  </Box>
+                )}
+              </Stack>
+            )}
           </Card.Body>
         </Card.Root>
       </Stack>

--- a/src/app/(header)/partner/supplier/page.tsx
+++ b/src/app/(header)/partner/supplier/page.tsx
@@ -10,12 +10,17 @@ import {
   Text,
   Card,
   Table,
+  Dialog,
+  Portal,
+  CloseButton,
+  Checkbox,
+  ActionBar,
 } from "@chakra-ui/react";
 import { HiChevronLeft, HiChevronRight } from "react-icons/hi";
-import { LuPlus } from "react-icons/lu";
+import { LuPlus, LuTrash2 } from "react-icons/lu";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { Supplier, SupplierResponse } from "@/types";
 import axiosClient from "@/lib/axiosClient";
@@ -26,10 +31,19 @@ const fetchSuppliers = async (url: string): Promise<SupplierResponse> => {
   return data;
 };
 
+// 複数の仕入先を削除する関数
+const deleteMultipleSuppliers = async (ids: number[]): Promise<void> => {
+  await axiosClient.post(`/api/masters/suppliers/bulk-delete/`, { ids });
+};
+
 export default function SupplierListPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   // APIのURLを状態として管理
   const [apiUrl, setApiUrl] = useState("/api/masters/suppliers/");
+  // 選択された仕入先のIDを管理
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const hasSelection = selectedIds.length > 0;
 
   // React Queryを使用してデータを取得
   const {
@@ -42,16 +56,65 @@ export default function SupplierListPage() {
     placeholderData: (previousData) => previousData,
   });
 
+  // 複数削除のミューテーション
+  const deleteMultipleMutation = useMutation({
+    mutationFn: deleteMultipleSuppliers,
+    onSuccess: (data) => {
+      // キャッシュの無効化
+      queryClient.invalidateQueries({ queryKey: ["suppliers"] });
+      // 選択をクリア
+      setSelectedIds([]);
+    },
+    onError: (error) => {
+      console.error("削除エラー:", error);
+    },
+  });
+
   // ページネーションハンドラー
   const handlePrevPage = () => {
     if (suppliers?.previous) {
       setApiUrl(suppliers.previous);
+      setSelectedIds([]); // ページ切り替え時に選択をクリア
     }
   };
 
   const handleNextPage = () => {
     if (suppliers?.next) {
       setApiUrl(suppliers.next);
+      setSelectedIds([]); // ページ切り替え時に選択をクリア
+    }
+  };
+
+  // チェックボックスの選択ハンドラー
+  const handleCheckboxChange = (id: number, checked: boolean) => {
+    setSelectedIds((prev) => {
+      if (checked) {
+        return [...prev, id];
+      } else {
+        return prev.filter((item) => item !== id);
+      }
+    });
+  };
+
+  // 全選択/全解除ハンドラー
+  const handleSelectAll = (isChecked: boolean) => {
+    setSelectedIds(
+      isChecked ? suppliers!.results.map((supplier) => supplier.id) : []
+    );
+  };
+
+  // 複数削除ハンドラー
+  const handleDeleteMultiple = () => {
+    if (selectedIds.length > 0) {
+      deleteMultipleMutation.mutate(selectedIds);
+    }
+  };
+
+  // 行クリックハンドラー - チェックボックスクリック時は詳細ページに遷移させない
+  const handleRowClick = (supplierId: number, event: React.MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (target.tagName !== "INPUT") {
+      router.push(`/partner/supplier/${supplierId}`);
     }
   };
 
@@ -84,6 +147,23 @@ export default function SupplierListPage() {
               <Table.Root interactive variant="outline" showColumnBorder>
                 <Table.Header bg="gray.50">
                   <Table.Row>
+                    <Table.Cell width="40px">
+                      <Checkbox.Root
+                        checked={
+                          hasSelection &&
+                          selectedIds.length < suppliers.results.length
+                            ? "indeterminate"
+                            : selectedIds.length > 0
+                        }
+                        onCheckedChange={(change) => {
+                          const isChecked = change?.checked === true;
+                          handleSelectAll(isChecked);
+                        }}
+                      >
+                        <Checkbox.HiddenInput />
+                        <Checkbox.Control />
+                      </Checkbox.Root>
+                    </Table.Cell>
                     <Table.Cell fontWeight="bold">仕入先名</Table.Cell>
                     <Table.Cell fontWeight="bold">仕入先コード</Table.Cell>
                     <Table.Cell fontWeight="bold">住所</Table.Cell>
@@ -95,11 +175,21 @@ export default function SupplierListPage() {
                   {suppliers.results.map((supplier: Supplier) => (
                     <Table.Row
                       key={supplier.id}
-                      onClick={() =>
-                        router.push(`/partner/supplier/${supplier.id}`)
-                      }
+                      onClick={(e) => handleRowClick(supplier.id, e)}
                       cursor="pointer"
                     >
+                      <Table.Cell onClick={(e) => e.stopPropagation()}>
+                        <Checkbox.Root
+                          checked={selectedIds.includes(supplier.id)}
+                          onCheckedChange={(change) => {
+                            const isChecked = change?.checked === true;
+                            handleCheckboxChange(supplier.id, isChecked);
+                          }}
+                        >
+                          <Checkbox.HiddenInput />
+                          <Checkbox.Control />
+                        </Checkbox.Root>
+                      </Table.Cell>
                       <Table.Cell>{supplier.name}</Table.Cell>
                       <Table.Cell>{supplier.supplier_code}</Table.Cell>
                       <Table.Cell>{`${supplier.prefecture}${supplier.city}`}</Table.Cell>
@@ -149,6 +239,58 @@ export default function SupplierListPage() {
           </Flex>
         </>
       ) : null}
+
+      {/* ActionBar for bulk actions */}
+      <ActionBar.Root open={hasSelection}>
+        <Portal>
+          <ActionBar.Positioner>
+            <ActionBar.Content>
+              <ActionBar.SelectionTrigger>
+                {selectedIds.length}件選択中
+              </ActionBar.SelectionTrigger>
+              <ActionBar.Separator />
+              <Dialog.Root>
+                <Dialog.Trigger asChild>
+                  <Button variant="surface" size="sm" colorPalette="red">
+                    <LuTrash2 />
+                    削除
+                  </Button>
+                </Dialog.Trigger>
+                <Portal>
+                  <Dialog.Backdrop />
+                  <Dialog.Positioner>
+                    <Dialog.Content>
+                      <Dialog.Header>
+                        <Dialog.Title>削除しますか?</Dialog.Title>
+                      </Dialog.Header>
+                      <Dialog.Body>
+                        選択した{selectedIds.length}
+                        件の仕入先を削除してもよろしいですか？
+                        この操作は取り消せません。
+                      </Dialog.Body>
+                      <Dialog.Footer>
+                        <Dialog.ActionTrigger asChild>
+                          <Button variant="outline">キャンセル</Button>
+                        </Dialog.ActionTrigger>
+                        <Button
+                          colorPalette="red"
+                          onClick={handleDeleteMultiple}
+                          disabled={deleteMultipleMutation.isPending}
+                        >
+                          削除する
+                        </Button>
+                      </Dialog.Footer>
+                      <Dialog.CloseTrigger asChild>
+                        <CloseButton size="sm" />
+                      </Dialog.CloseTrigger>
+                    </Dialog.Content>
+                  </Dialog.Positioner>
+                </Portal>
+              </Dialog.Root>
+            </ActionBar.Content>
+          </ActionBar.Positioner>
+        </Portal>
+      </ActionBar.Root>
     </Box>
   );
 }

--- a/src/app/(header)/partner/supplier/page.tsx
+++ b/src/app/(header)/partner/supplier/page.tsx
@@ -95,7 +95,10 @@ export default function SupplierListPage() {
                   {suppliers.results.map((supplier: Supplier) => (
                     <Table.Row
                       key={supplier.id}
-                      onClick={() => router.push(`#`)}
+                      onClick={() =>
+                        router.push(`/partner/supplier/${supplier.id}`)
+                      }
+                      cursor="pointer"
                     >
                       <Table.Cell>{supplier.name}</Table.Cell>
                       <Table.Cell>{supplier.supplier_code}</Table.Cell>


### PR DESCRIPTION
## 概要

このプルリクエストでは、仕入先の詳細表示、登録、編集、削除（個別および一括）機能を提供し、同時編集による競合を防止する仕組みも導入しています。

## 変更内容

- **仕入先詳細表示機能**
  - 仕入先の基本情報（名称、コード、連絡先等）と住所情報の表示

- **仕入先編集機能**
  - 各種バリデーションルールの設定（必須チェック、文字数制限、形式チェック）
  - 同時編集検出機能（楽観的ロック）の実装
    - 編集開始時と保存時の`updated_at`比較による変更検出
    - 競合検出時のユーザー選択機能（上書き保存/変更確認/キャンセル）

- **仕入先削除機能**
  - 個別削除機能（詳細画面から削除）
  - 複数一括削除機能（一覧画面からの選択削除）
  - 削除前の確認ダイアログ

## 関連情報
- 関連Issue: https://github.com/goayasushi/zaiko-be/issues/15