### PR TITLE
部品一覧表示機能の実装

### DIFF
--- a/src/app/(header)/part/new/page.tsx
+++ b/src/app/(header)/part/new/page.tsx
@@ -279,7 +279,7 @@ export default function NewPartPage() {
                   min={0}
                   max={1}
                   step={0.01}
-                  defaultValue={String(field.value * 100)}
+                  defaultValue={String(field.value ? field.value * 100 : 10)}
                   onValueChange={(value) => field.onChange(value.valueAsNumber)}
                   formatOptions={{
                     style: "percent",

--- a/src/app/(header)/part/page.tsx
+++ b/src/app/(header)/part/page.tsx
@@ -5,15 +5,90 @@ import {
   Button,
   Flex,
   Heading,
+  Icon,
   Stack,
   Text,
   Card,
+  Table,
+  Checkbox,
 } from "@chakra-ui/react";
+import { HiChevronLeft, HiChevronRight } from "react-icons/hi";
 import { LuPlus } from "react-icons/lu";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
+import { Part, PartResponse } from "@/types";
+import axiosClient from "@/lib/axiosClient";
+import { PART_CATEGORY_LABELS } from "@/constants/partCategories";
+
+// 部品データを取得する関数
+const fetchParts = async (url: string): Promise<PartResponse> => {
+  const { data } = await axiosClient.get<PartResponse>(url);
+  return data;
+};
 
 export default function PartListPage() {
   const router = useRouter();
+
+  // APIのURLを状態として管理
+  const [apiUrl, setApiUrl] = useState("/api/masters/parts/");
+  // 選択された部品のIDを管理
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const hasSelection = selectedIds.length > 0;
+
+  // React Queryを使用してデータを取得
+  const {
+    data: parts,
+    isLoading,
+    isError,
+  } = useQuery<PartResponse>({
+    queryKey: ["parts", apiUrl],
+    queryFn: () => fetchParts(apiUrl),
+    placeholderData: (previousData: PartResponse | undefined) => previousData,
+  });
+
+  // ページネーションハンドラー
+  const handlePrevPage = () => {
+    if (parts?.previous) {
+      setApiUrl(parts.previous);
+      setSelectedIds([]); // ページ切り替え時に選択をクリア
+    }
+  };
+
+  const handleNextPage = () => {
+    if (parts?.next) {
+      setApiUrl(parts.next);
+      setSelectedIds([]); // ページ切り替え時に選択をクリア
+    }
+  };
+
+  // チェックボックスの選択ハンドラー
+  const handleCheckboxChange = (id: number, checked: boolean) => {
+    setSelectedIds((prev) => {
+      if (checked) {
+        return [...prev, id];
+      } else {
+        return prev.filter((item) => item !== id);
+      }
+    });
+  };
+
+  // 全選択/全解除ハンドラー
+  const handleSelectAll = (isChecked: boolean) => {
+    if (!parts) return;
+
+    setSelectedIds(isChecked ? parts.results.map((part) => part.id) : []);
+  };
+
+  // 行クリックハンドラー - チェックボックスクリック時は詳細ページに遷移させない
+  const handleRowClick = (partId: number, event: React.MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (target.tagName !== "INPUT") {
+      // 詳細画面は実装しないのでダミーリンク
+      console.log(`部品ID: ${partId} の詳細を表示`);
+    }
+  };
 
   return (
     <Box>
@@ -33,26 +108,115 @@ export default function PartListPage() {
         </Stack>
       </Flex>
 
-      <Card.Root>
-        <Card.Body p={6}>
+      {isLoading ? (
+        <Text>読み込み中...</Text>
+      ) : isError ? (
+        <Text color="red.500">エラーが発生しました。再度お試しください。</Text>
+      ) : parts ? (
+        <>
+          <Card.Root>
+            <Box overflowX="auto">
+              <Table.Root interactive variant="outline" showColumnBorder>
+                <Table.Header bg="gray.50">
+                  <Table.Row>
+                    <Table.Cell width="40px">
+                      <Checkbox.Root
+                        checked={
+                          hasSelection &&
+                          selectedIds.length < parts.results.length
+                            ? "indeterminate"
+                            : selectedIds.length > 0
+                        }
+                        onCheckedChange={(change) => {
+                          const isChecked = change?.checked === true;
+                          handleSelectAll(isChecked);
+                        }}
+                      >
+                        <Checkbox.HiddenInput />
+                        <Checkbox.Control />
+                      </Checkbox.Root>
+                    </Table.Cell>
+                    <Table.Cell fontWeight="bold">部品名</Table.Cell>
+                    <Table.Cell fontWeight="bold">カテゴリ</Table.Cell>
+                    <Table.Cell fontWeight="bold">仕入先</Table.Cell>
+                    <Table.Cell fontWeight="bold">原価</Table.Cell>
+                    <Table.Cell fontWeight="bold">見積用単価</Table.Cell>
+                    <Table.Cell fontWeight="bold">在庫数</Table.Cell>
+                    <Table.Cell fontWeight="bold">補充閾値</Table.Cell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {parts.results.map((part: Part) => (
+                    <Table.Row
+                      key={part.id}
+                      onClick={(e) => handleRowClick(part.id, e)}
+                      cursor="pointer"
+                    >
+                      <Table.Cell onClick={(e) => e.stopPropagation()}>
+                        <Checkbox.Root
+                          checked={selectedIds.includes(part.id)}
+                          onCheckedChange={(change) => {
+                            const isChecked = change?.checked === true;
+                            handleCheckboxChange(part.id, isChecked);
+                          }}
+                        >
+                          <Checkbox.HiddenInput />
+                          <Checkbox.Control />
+                        </Checkbox.Root>
+                      </Table.Cell>
+                      <Table.Cell>{part.name}</Table.Cell>
+                      <Table.Cell>
+                        {PART_CATEGORY_LABELS[part.category]}
+                      </Table.Cell>
+                      <Table.Cell>{part.supplier.name}</Table.Cell>
+                      <Table.Cell>¥{part.cost_price}</Table.Cell>
+                      <Table.Cell>¥{part.selling_price}</Table.Cell>
+                      <Table.Cell>{part.stock_quantity}</Table.Cell>
+                      <Table.Cell>{part.reorder_level}</Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            </Box>
+          </Card.Root>
+
           <Flex
-            direction="column"
-            justify="center"
+            mt={4}
+            justify="space-between"
             align="center"
-            minHeight="200px"
-            gap={4}
+            fontSize="sm"
+            color="gray.600"
           >
-            <Text color="gray.500">部品一覧はこれから実装される予定です</Text>
-            <Button
-              variant="outline"
-              colorScheme="blue"
-              onClick={() => router.push("/part/new")}
-            >
-              新しい部品を登録する
-            </Button>
+            <Flex align="center" gap={1}>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={!parts.previous}
+                onClick={handlePrevPage}
+              >
+                <Icon as={HiChevronLeft} />
+              </Button>
+              <Text>
+                {parts.current} / {parts.total_pages}
+              </Text>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={!parts.next}
+                onClick={handleNextPage}
+              >
+                <Icon as={HiChevronRight} />
+              </Button>
+            </Flex>
+
+            <Flex align="center" gap={2}>
+              <Text>
+                {parts.page_size}件/ページ 全{parts.count || 0}件
+              </Text>
+            </Flex>
           </Flex>
-        </Card.Body>
-      </Card.Root>
+        </>
+      ) : null}
     </Box>
   );
 }

--- a/src/types/part.ts
+++ b/src/types/part.ts
@@ -1,3 +1,6 @@
+import { User } from "./user";
+import { SupplierSimple } from "./supplier";
+
 /**
  * 部品情報の型定義
  * APIから取得される部品データの形式
@@ -6,17 +9,16 @@ export type Part = {
   id: number;
   name: string;
   category: string;
-  supplier_id: number;
-  supplier_name?: string;
-  cost_price: number;
-  selling_price: number;
-  tax_rate: number;
+  supplier: SupplierSimple;
+  cost_price: string;
+  selling_price: string;
+  tax_rate: string;
   stock_quantity: number;
   reorder_level: number;
   description: string;
   image: string | null;
-  created_by?: number;
-  updated_by?: number;
+  created_by?: User;
+  updated_by?: User;
   created_at?: string;
   updated_at?: string;
 };
@@ -25,14 +27,29 @@ export type Part = {
  * 部品フォームの型定義
  * フォーム入力用の型
  */
-export type PartFormData = Omit<
-  Part,
-  | "id"
-  | "created_at"
-  | "updated_at"
-  | "created_by"
-  | "updated_by"
-  | "supplier_name"
-> & {
+export type PartFormData = {
+  name: string;
+  category: string;
+  supplier_id: number;
+  cost_price: string | number;
+  selling_price: string | number;
+  tax_rate?: number;
+  stock_quantity: number;
+  reorder_level: number;
+  description?: string;
   image_file?: File;
+};
+
+/**
+ * 部品一覧レスポンスの型定義
+ * APIからのレスポンス形式
+ */
+export type PartResponse = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Part[];
+  page_size: number;
+  current: number;
+  total_pages: number;
 };

--- a/src/types/supplier.ts
+++ b/src/types/supplier.ts
@@ -22,6 +22,15 @@ export type Supplier = {
 };
 
 /**
+ * 仕入先簡易情報の型定義
+ * API応答に含まれる簡略化された仕入先情報
+ */
+export type SupplierSimple = {
+  id: number;
+  name: string;
+};
+
+/**
  * 仕入先フォームの型定義
  * フォーム入力用の型
  */


### PR DESCRIPTION
## 概要

このプルリクエストでは、部品登録・部品一覧表示のフロントエンドを、バックエンドの型定義変更に合わせて修正・実装しました。
具体的には、TypeScript の型定義を更新し、一覧画面にテーブル表示・チェックボックス選択・ページネーションを追加しています。

## 変更内容

* **型定義の更新 (`src/types/part.ts`)**

  * `Part` 型における `cost_price` / `selling_price` / `tax_rate` を `number` → `string` に変更
  * `supplier` を `supplier_id`+`supplier_name` からネストされた `SupplierSimple` オブジェクトへ移行
  * `created_by` / `updated_by` を単なる ID → `User` オブジェクト型に変更
  * `PartFormData` 型をフォーム送信用に再定義

* **部品一覧画面の実装 (`src/app/(header)/part/page.tsx`)**

  * Chakra UI の `Table` コンポーネントで一覧表示を実装
  * 行ごとのチェックボックスと「全選択／全解除」を追加
  * React Query でページネーション情報を取得し、前後ページ切替ボタンを配置
  * 部品名、カテゴリ、仕入先、金額、在庫数、補充閾値などをテーブル列として表示

## 関連情報

* 関連Issue: https://github.com/goayasushi/zaiko-be/issues/11
